### PR TITLE
Legacy Notification Payload Modifications

### DIFF
--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -261,8 +261,13 @@ func GetLegacyIOSNotification(req PushNotification) *apns2.Notification {
 
 	payload := payload.NewPayload()
 
-	for k, v := range req.Data {
-		payload.Custom(k, v)
+	if aps, ok := req.Data["aps"]; ok {
+		payload.Custom("aps", aps)
+		delete(req.Data, "aps")
+	}
+
+	if len(req.Data) > 0 {
+		payload.Custom("data", req.Data)
 	}
 
 	notification.Payload = payload


### PR DESCRIPTION
- "aps" payload is extracted from "data" payload, then deleting the key
- after that if data payload still contains some keys, then set "data"
- following modifications are done as per purple app payload